### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,11 +149,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759831965,
-        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
         "type": "github"
       },
       "original": {

--- a/utils/patched-nix/nix-expose-apis.patch
+++ b/utils/patched-nix/nix-expose-apis.patch
@@ -75,7 +75,7 @@ index 2254f18fa..5ade80343 100644
 +}
 +
 +char * sign_detached(const char * secret_key, const char * data) {
-+    return strdup(nix::SecretKey(secret_key).signDetached(data).c_str());
++    return strdup(nix::SecretKey(secret_key).signDetached(data).sig.c_str());
 +}
  // internal
  nix_err call_nix_get_string_callback(const std::string str, nix_get_string_callback callback, void * user_data)


### PR DESCRIPTION
We're patching nix here because at some point we thought we could/would upstream the C bindings for the API's we need. Possibly we should reconsider that approach, as I'm no longer sure we'll find the energy for that.